### PR TITLE
Navigation prop types

### DIFF
--- a/src/navigation/NavigationPropTypes.js
+++ b/src/navigation/NavigationPropTypes.js
@@ -17,6 +17,16 @@ export const NavigationRoutePropType = {
   params: PropTypes.object.isRequired,
 };
 
+/*
+  Use this object as A COPY, not as a reference.
+  For example:
+  MyScreen.propTypes = {
+    ...NavigationProps,
+  };
+
+  Instead of:
+  MyScreen.propTypes = NavigationProps;
+*/
 export const NavigationProps = {
   navigation: PropTypes.shape({ ...NavigationPropType }),
   route: PropTypes.shape({ ...NavigationRoutePropType }),

--- a/src/navigation/NavigationPropTypes.js
+++ b/src/navigation/NavigationPropTypes.js
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types';
+
+export const NavigationPropType = {
+  navigate: PropTypes.func.isRequired,
+  reset: PropTypes.func.isRequired,
+  goBack: PropTypes.func.isRequired,
+  setParams: PropTypes.func.isRequired,
+  dispatch: PropTypes.func.isRequired,
+  setOptions: PropTypes.func.isRequired,
+  isFocused: PropTypes.func.isRequired,
+  addListener: PropTypes.func.isRequired,
+};
+
+export const NavigationRoutePropType = {
+  key: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  params: PropTypes.object.isRequired,
+};
+
+export const NavigationProps = {
+  navigation: PropTypes.shape({ ...NavigationPropType }),
+  route: PropTypes.shape({ ...NavigationRoutePropType }),
+};


### PR DESCRIPTION
## What does this PR do?
Adds the navigation and route prop types for use in screen components for better prop typing. For example:
```
import {NavigationProps} from './navigation/NavigationPropTypes';

function MyScreenComponent({ navigation, route }) {
  return ( ... );
}
MyScreenComponent.propTypes = {
  ...NavigationProps,
};
```

## Related issues this PR closes or is related to

Closes none.
